### PR TITLE
Update create-image.sh for EoL Debian releases

### DIFF
--- a/guestimage/create-image.sh
+++ b/guestimage/create-image.sh
@@ -148,7 +148,16 @@ fi
 if [ $DEBARCH == "riscv64" ]; then
     DEBOOTSTRAP_PARAMS="--keyring /usr/share/keyrings/debian-ports-archive-keyring.gpg --exclude firmware-atheros $DEBOOTSTRAP_PARAMS http://deb.debian.org/debian-ports"
 fi
-sudo --preserve-env=http_proxy,https_proxy,ftp_proxy,no_proxy debootstrap $DEBOOTSTRAP_PARAMS
+
+# debootstrap may fail for EoL Debian releases
+RET=0
+sudo --preserve-env=http_proxy,https_proxy,ftp_proxy,no_proxy debootstrap $DEBOOTSTRAP_PARAMS || RET=$?
+
+if [ $RET != 0 ] && [ $DEBARCH != "riscv64" ]; then
+    # Try running debootstrap again using the Debian archive
+    DEBOOTSTRAP_PARAMS="--keyring /usr/share/keyrings/debian-archive-removed-keys.gpg $DEBOOTSTRAP_PARAMS https://archive.debian.org/debian-archive/debian/"
+    sudo --preserve-env=http_proxy,https_proxy,ftp_proxy,no_proxy debootstrap $DEBOOTSTRAP_PARAMS
+fi
 
 # 2. debootstrap stage: only necessary if target != host architecture
 


### PR DESCRIPTION
Debootstrap fails for EoL Debian releases (including stretch on my system). The fix is copied from the [syzkaller](https://github.com/google/syzkaller) repo.